### PR TITLE
Correct the warning in VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
Correct the warning in VS Code:
> GIT: The git repository at XXXX has too many active changes, only a subset of Git features will be enabled.

This happens, because node_modules folder should be created according to the [help](https://help.sap.com/viewer/4505d0bdaf4948449b7f7379d24d0f0d/2.0.02/en-US/0919e1cbd20646aead930a5743cfa7e1.html) article.
> Copy the node_modules folder from the central location where you stored it after download to the new application's xsjs/ and web/ folders

Signed-off-by: Vest <Vest@users.noreply.github.com>